### PR TITLE
Doc: Note usage of splitlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@
   - do not use ANY state in Manager objects
   - for fields being used in queries - are those fields indexed? Should they be?
 
+## Python Eggs
+
+  - Use `splitlines()` instead of `split("\n")` in `setup.py`
 
 ## JavaScript / Ember
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 ## Python Eggs
 
   - Use `splitlines()` instead of `split("\n")` in `setup.py`
+    e.g. `install_requires=open('requirements/requirements.txt').read().splitlines()`
 
 ## JavaScript / Ember
 


### PR DESCRIPTION
split('\n') can give an empty element in the produced array and subsequently cause the building of the wheel to fail. A wheel is always built, even if just the tar ball is uploaded and installed. The tar ball is downloaded and the wheel built locally in that case.